### PR TITLE
Fix ExcelDna.AddIn package reference

### DIFF
--- a/TestAddIn/TestAddIn.fsproj
+++ b/TestAddIn/TestAddIn.fsproj
@@ -16,9 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ExcelDna.AddIn" Version="1.1.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="ExcelDna.AddIn" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
NuGet no longer adds a reference to transitive assemblies when a package is marked as development dependency... The assembly in question is `ExcelDna.Integration`.